### PR TITLE
Add support for default forecolor/backcolor (SGR 39/49)

### DIFF
--- a/code/src/casciian/TDesktop.java
+++ b/code/src/casciian/TDesktop.java
@@ -14,7 +14,9 @@
  */
 package casciian;
 
+import casciian.bits.Cell;
 import casciian.bits.CellAttributes;
+import casciian.bits.ComplexCell;
 import casciian.bits.GraphicsChars;
 import casciian.event.TKeypressEvent;
 import casciian.event.TMenuEvent;
@@ -39,6 +41,16 @@ import casciian.event.TResizeEvent;
 public class TDesktop extends TWindow {
 
     // ------------------------------------------------------------------------
+    // Variables --------------------------------------------------------------
+    // ------------------------------------------------------------------------
+
+    /**
+     * The background character to use, or null to use the default background
+     * color (SGR 49).
+     */
+    private ComplexCell backgroundCell = null;
+
+    // ------------------------------------------------------------------------
     // Constructors -----------------------------------------------------------
     // ------------------------------------------------------------------------
 
@@ -53,6 +65,8 @@ public class TDesktop extends TWindow {
             parent.getDesktopBottom() - parent.getDesktopTop());
 
         setActive(false);
+
+        backgroundCell = new ComplexCell(GraphicsChars.HATCH);
     }
 
     // ------------------------------------------------------------------------
@@ -193,8 +207,12 @@ public class TDesktop extends TWindow {
      */
     @Override
     public void draw() {
-        CellAttributes background = getTheme().getColor("tdesktop.background");
-        putAll(GraphicsChars.HATCH, background);
+        assert (backgroundCell != null);
+
+        if (!backgroundCell.isDefaultColor(false)) {
+            backgroundCell.setTo(getTheme().getColor("tdesktop.background"));
+        }
+        putAll(backgroundCell);
 
         /*
         // For debugging, let's see where the desktop bounds really are.
@@ -259,6 +277,26 @@ public class TDesktop extends TWindow {
     @Override
     protected final boolean mouseOnResize() {
         return false;
+    }
+
+    // ------------------------------------------------------------------------
+    // TDesktop ---------------------------------------------------------------
+    // ------------------------------------------------------------------------
+
+    /**
+     * Set the background cell.
+     *
+     * @param cell the cell, or null to use the terminal's default foreground
+     * and background colors.
+     */
+    public void setBackgroundCell(final Cell cell) {
+        if (cell != null) {
+            backgroundCell = new ComplexCell(cell);
+        } else {
+            backgroundCell = new ComplexCell();
+            backgroundCell.setDefaultColor(true, true);
+            backgroundCell.setDefaultColor(false, true);
+        }
     }
 
 }

--- a/code/src/casciian/TWidget.java
+++ b/code/src/casciian/TWidget.java
@@ -2101,6 +2101,15 @@ public abstract class TWidget implements Comparable<TWidget> {
     }
 
     /**
+     * Fill the entire screen with one cell.
+     *
+     * @param ch the character to draw
+     */
+    public final void putAll(final Cell ch) {
+        getScreen().putAll(ch);
+    }
+
+    /**
      * Fill the entire screen with one character with attributes.
      *
      * @param ch character to draw

--- a/code/src/casciian/backend/Backend.java
+++ b/code/src/casciian/backend/Backend.java
@@ -133,4 +133,18 @@ public interface Backend {
      */
     public boolean isFocused();
 
+    /**
+     * Retrieve the default foreground color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultForeColorRGB();
+
+    /**
+     * Retrieve the default background color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultBackColorRGB();
+
 }

--- a/code/src/casciian/backend/ECMA48Backend.java
+++ b/code/src/casciian/backend/ECMA48Backend.java
@@ -223,4 +223,22 @@ public class ECMA48Backend extends GenericBackend {
         return ((ECMA48Terminal) terminal).isFocused();
     }
 
+    /**
+     * Retrieve the default foreground color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultForeColorRGB() {
+        return ((ECMA48Terminal) terminal).getDefaultForeColorRGB();
+    }
+
+    /**
+     * Retrieve the default background color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultBackColorRGB() {
+        return ((ECMA48Terminal) terminal).getDefaultBackColorRGB();
+    }
+
 }

--- a/code/src/casciian/backend/HeadlessBackend.java
+++ b/code/src/casciian/backend/HeadlessBackend.java
@@ -189,6 +189,26 @@ public class HeadlessBackend extends LogicalScreen implements Backend {
     }
 
     /**
+     * Retrieve the default foreground color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultForeColorRGB() {
+        // Use ECMA48 colors.
+        return ECMA48Terminal.getDefaultForeColorRGB();
+    }
+
+    /**
+     * Retrieve the default background color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultBackColorRGB() {
+        // Use ECMA48 colors.
+        return ECMA48Terminal.getDefaultBackColorRGB();
+    }
+
+    /**
      * Copy text to the system clipboard of the terminal on the backend.
      *
      * @param text string to copy

--- a/code/src/casciian/backend/LogicalScreen.java
+++ b/code/src/casciian/backend/LogicalScreen.java
@@ -641,6 +641,19 @@ public class LogicalScreen implements Screen {
     }
 
     /**
+     * Fill the entire screen with one cell.
+     *
+     * @param ch the character to draw
+     */
+    public final void putAll(final Cell ch) {
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                putCharXY(x, y, ch);
+            }
+        }
+    }
+
+    /**
      * Render one character with attributes.
      *
      * @param x column coordinate.  0 is the left-most column.
@@ -1471,6 +1484,10 @@ public class LogicalScreen implements Screen {
         } else {
             cell.setBackColorRGB(cell.getBackColorRGB() ^ 0x00ffffff);
         }
+
+        cell.setDefaultColor(true, false);
+        cell.setDefaultColor(false, false);
+
         putCharXY(x, y, cell, true);
         if ((onlyThisCell == true) || (cell.getWidth() == Cell.Width.SINGLE)) {
             return;
@@ -1807,6 +1824,23 @@ public class LogicalScreen implements Screen {
         if (alpha == 255) {
             // This is a raw copy.
             copyScreen(otherScreen, x, y, width, height);
+            synchronized (this) {
+                for (int row = y; (row < y + height) && (row < this.height); row++) {
+                    if (row < 0) {
+                        continue;
+                    }
+                    for (int col = x; (col < x + width) && (col < this.width); col++) {
+                        if (col < 0) {
+                            continue;
+                        }
+                        Cell thisCell = logical[col][row];
+                        // Overlapped cells will not have DEFAULT (SGR 39/49)
+                        // colors set.
+                        thisCell.setDefaultColor(true, false);
+                        thisCell.setDefaultColor(false, false);
+                    }
+                }
+            }
             return;
         }
 
@@ -1918,6 +1952,11 @@ public class LogicalScreen implements Screen {
 
                     thisCell.setBackColorRGB(thisBg | OPAQUE);
                     thisCell.setForeColorRGB(thisFg | OPAQUE);
+
+                    // Overlapped cells will not have DEFAULT (SGR 39/49)
+                    // colors set.
+                    thisCell.setDefaultColor(true, false);
+                    thisCell.setDefaultColor(false, false);
 
                     if (overCell.isSpaceChar() && !overCell.isUnderline()) {
                         // The overlaying cell is invisible.

--- a/code/src/casciian/backend/MultiBackend.java
+++ b/code/src/casciian/backend/MultiBackend.java
@@ -340,6 +340,26 @@ public class MultiBackend implements Backend {
     }
 
     /**
+     * Retrieve the default foreground color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultForeColorRGB() {
+        // Use ECMA48 colors.
+        return ECMA48Terminal.getDefaultForeColorRGB();
+    }
+
+    /**
+     * Retrieve the default background color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultBackColorRGB() {
+        // Use ECMA48 colors.
+        return ECMA48Terminal.getDefaultBackColorRGB();
+    }
+
+    /**
      * Copy text to the system clipboard of the terminal on the backend.  Not
      * all terminals support this (OSC 52).
      *

--- a/code/src/casciian/backend/Screen.java
+++ b/code/src/casciian/backend/Screen.java
@@ -226,6 +226,13 @@ public interface Screen {
     public void putAll(final int ch, final CellAttributes attr);
 
     /**
+     * Fill the entire screen with one cell.
+     *
+     * @param ch the character to draw
+     */
+    public void putAll(final Cell ch);
+
+    /**
      * Render one character with attributes.
      *
      * @param x column coordinate.  0 is the left-most column.

--- a/code/src/casciian/backend/TWindowBackend.java
+++ b/code/src/casciian/backend/TWindowBackend.java
@@ -568,6 +568,24 @@ public class TWindowBackend extends TWindow implements Backend {
     }
 
     /**
+     * Retrieve the default foreground color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultForeColorRGB() {
+        return getApplication().getBackend().getDefaultForeColorRGB();
+    }
+
+    /**
+     * Retrieve the default background color.
+     *
+     * @return the RGB color
+     */
+    public int getDefaultBackColorRGB() {
+        return getApplication().getBackend().getDefaultForeColorRGB();
+    }
+
+    /**
      * Copy text to the Casciian clipboard.
      *
      * @param text string to copy

--- a/code/src/casciian/bits/CellAttributes.java
+++ b/code/src/casciian/bits/CellAttributes.java
@@ -51,6 +51,16 @@ public class CellAttributes {
     private static final int PROTECT    = 0x10;
 
     /**
+     * Default foreground color.
+     */
+    private static final int DEFAULT_FORECOLOR    = 0x20;
+
+    /**
+     * Default background color.
+     */
+    private static final int DEFAULT_BACKCOLOR    = 0x40;
+
+    /**
      * Animation bits for time-dependent transforms.
      */
     private static final int ANIMATION_MASK       = 0xFFFFF000;
@@ -242,6 +252,43 @@ public class CellAttributes {
         } else {
             flags &= ~PROTECT;
         }
+    }
+
+    /**
+     * Setter for default color.
+     *
+     * @param foreground if true, set the default for the foreground color
+     * @param defaultColor new default value
+     */
+    public final void setDefaultColor(final boolean foreground,
+        final boolean defaultColor) {
+
+        if (foreground) {
+            if (defaultColor) {
+                flags |= DEFAULT_FORECOLOR;
+            } else {
+                flags &= ~DEFAULT_FORECOLOR;
+            }
+        } else {
+            if (defaultColor) {
+                flags |= DEFAULT_BACKCOLOR;
+            } else {
+                flags &= ~DEFAULT_BACKCOLOR;
+            }
+        }
+    }
+
+    /**
+     * Getter for default color.
+     *
+     * @param foreground if true, get the default for the foreground color
+     * @return true if the default color has been set
+     */
+    public final boolean isDefaultColor(final boolean foreground) {
+        if (foreground) {
+            return ((flags & DEFAULT_FORECOLOR) == 0 ? false : true);
+        }
+        return ((flags & DEFAULT_BACKCOLOR) == 0 ? false : true);
     }
 
     /**

--- a/code/src/demo/DemoApplication.java
+++ b/code/src/demo/DemoApplication.java
@@ -53,6 +53,11 @@ public class DemoApplication extends TApplication {
      */
     private ResourceBundle i18n = ResourceBundle.getBundle(DemoApplication.class.getName());
 
+    /**
+     * The desktop visible before selecting "Expose terminal background image".
+     */
+    private TDesktop oldDesktop = null;
+
     // ------------------------------------------------------------------------
     // Constructors -----------------------------------------------------------
     // ------------------------------------------------------------------------
@@ -145,6 +150,10 @@ public class DemoApplication extends TApplication {
         // Use window gradients by default.
         getMenuItem(10010).setChecked(true);
         onMenu(new TMenuEvent(getBackend(), 10010));
+
+        // Expose terminal background image by default.
+        // getMenuItem(10011).setChecked(true);
+        // onMenu(new TMenuEvent(getBackend(), 10011));
     }
 
     /**
@@ -170,6 +179,10 @@ public class DemoApplication extends TApplication {
         // Use window gradients by default.
         getMenuItem(10010).setChecked(true);
         onMenu(new TMenuEvent(getBackend(), 10010));
+
+        // Expose terminal background image by default.
+        // getMenuItem(10011).setChecked(true);
+        // onMenu(new TMenuEvent(getBackend(), 10011));
     }
 
     // ------------------------------------------------------------------------
@@ -249,7 +262,9 @@ public class DemoApplication extends TApplication {
                 m.setAlpha(90 * 255 / 100);
             }
             setDesktop(null);
+            oldDesktop = getDesktop();
             setHideStatusBar(true);
+            onMenu(new TMenuEvent(getBackend(), 10011));
             return true;
         }
 
@@ -295,7 +310,9 @@ public class DemoApplication extends TApplication {
                 m.setAlpha(90 * 255 / 100);
             }
             setDesktop(new TDesktop(this));
+            oldDesktop = getDesktop();
             setHideStatusBar(false);
+            onMenu(new TMenuEvent(getBackend(), 10011));
             return true;
         }
 
@@ -333,7 +350,9 @@ public class DemoApplication extends TApplication {
                 m.setAlpha(95 * 255 / 100);
             }
             setDesktop(new TDesktop(this));
+            oldDesktop = getDesktop();
             setHideStatusBar(false);
+            onMenu(new TMenuEvent(getBackend(), 10011));
             return true;
         }
 
@@ -369,6 +388,21 @@ public class DemoApplication extends TApplication {
                 if (window instanceof DemoCheckBoxWindow) {
                     ((DemoCheckBoxWindow) window).setUseGradient(useGradient);
                 }
+            }
+            return true;
+        }
+
+        if (menu.getId() == 10011) {
+            // Expose/cover terminal background.
+            TMenuItem menuItem = getMenuItem(menu.getId());
+            boolean exposeBackground = menuItem.isChecked();
+            if (exposeBackground) {
+                oldDesktop = getDesktop();
+                TDesktop newDesktop = new TDesktop(this);
+                setDesktop(newDesktop);
+                newDesktop.setBackgroundCell(null);
+            } else {
+                setDesktop(oldDesktop);
             }
             return true;
         }
@@ -434,6 +468,10 @@ public class DemoApplication extends TApplication {
             i18n.getString("useGradients"));
         gradients.setCheckable(true);
         gradients.setChecked(false);
+        TMenuItem backgroundImage = demoMenu.addItem(10011,
+            i18n.getString("exposeBackground"));
+        backgroundImage.setCheckable(true);
+        backgroundImage.setChecked(false);
         TSubMenu languageMenu = demoMenu.addSubMenu(i18n.getString("selectLanguage"));
         TMenuItem en = languageMenu.addItem(10005, i18n.getString("english"));
         TMenuItem es = languageMenu.addItem(10006, i18n.getString("espanol"));

--- a/code/src/demo/DemoApplication.properties
+++ b/code/src/demo/DemoApplication.properties
@@ -18,3 +18,4 @@ checkableSub=&Checkable (sub)
 disabledSub=Disabled (sub)
 normalSub=&Normal (sub)
 useGradients=G&radient backgrounds
+exposeBackground=E&xpose terminal background image

--- a/code/src/demo/DemoApplication_es.properties
+++ b/code/src/demo/DemoApplication_es.properties
@@ -18,3 +18,4 @@ checkableSub=&Marcable (sub)
 disabledSub=Desactivada (sub)
 normalSub=N&ormal (sub)
 useGradients=&Fondos degradados
+exposeBackground=E&xponer imagen de fondo del terminal


### PR DESCRIPTION
Support default forecolor/backcolor (SGR 39/49), permitting (on terminals that have the option) the terminal background image to be exposed.  A similar change was made for Jexer here: https://gitlab.com/AutumnMeowMeow/jexer/-/issues/168 .

Since I (Autumn Lamonte) am the author of the code there and here, I declare that:

    To the extent possible under law, the author(s) have dedicated all
    copyright and related and neighboring rights to this software to
    the public domain worldwide. This software is distributed without
    any warranty.

    You should have received a copy of the CC0 Public Domain
    Dedication along with this software. If not, see
    <http://creativecommons.org/publicdomain/zero/1.0/>.