### PR TITLE
Refine menu handling

### DIFF
--- a/code/src/main/java/casciian/TEditorWindow.java
+++ b/code/src/main/java/casciian/TEditorWindow.java
@@ -160,6 +160,7 @@ public class TEditorWindow extends TScrollableWindow {
      * Called by application.switchWindow() when this window gets the
      * focus, and also by application.addWindow().
      */
+    @Override
     public void onFocus() {
         super.onFocus();
         getApplication().enableMenuItem(TMenu.MID_UNDO);
@@ -170,6 +171,7 @@ public class TEditorWindow extends TScrollableWindow {
      * Called by application.switchWindow() when another window gets the
      * focus.
      */
+    @Override
     public void onUnfocus() {
         super.onUnfocus();
         getApplication().disableMenuItem(TMenu.MID_UNDO);
@@ -465,9 +467,7 @@ public class TEditorWindow extends TScrollableWindow {
             i18n.getString("statusBarHelp"));
         statusBar.addShortcutKeypress(kbF2, cmSave,
             i18n.getString("statusBarSave"));
-        statusBar.addShortcutKeypress(kbF3, cmSaveAs,
-            i18n.getString("statusBarSaveAs"));
-        statusBar.addShortcutKeypress(kbF4, cmOpen,
+        statusBar.addShortcutKeypress(kbF3, cmOpen,
             i18n.getString("statusBarOpen"));
         statusBar.addShortcutKeypress(kbShiftF10, cmMenu,
             i18n.getString("statusBarMenu"));

--- a/code/src/main/java/casciian/menu/TMenu.java
+++ b/code/src/main/java/casciian/menu/TMenu.java
@@ -929,6 +929,7 @@ public class TMenu extends TWindow {
 
         case MID_SAVE_FILE:
             label = i18n.getString("menuSave");
+            key = kbF2;
             icon = 0x1F4BE;
             break;
 

--- a/code/src/main/resources/casciian/menu/TMenuBundle.properties
+++ b/code/src/main/resources/casciian/menu/TMenuBundle.properties
@@ -1,9 +1,9 @@
 menuNew=&New
 menuExit=E&xit
-menuShell=O&S Shell
-menuOpen=&Open
-menuSave=Save
-menuSaveAs=Save as...
+menuShell=OS Shell
+menuOpen=&Open...
+menuSave=&Save
+menuSaveAs=Save &as...
 
 menuUndo=&Undo
 menuRedo=&Redo

--- a/code/src/main/resources/casciian/menu/TMenuBundle_es.properties
+++ b/code/src/main/resources/casciian/menu/TMenuBundle_es.properties
@@ -1,9 +1,9 @@
 menuNew=&Nuevo
 menuExit=&Salir
 menuShell=&L\u00ednea de comandos
-menuOpen=&Abrir
-menuSave=Guardar
-menuSaveAs=Guardar como...
+menuOpen=&Abrir...
+menuSave=&Guardar
+menuSaveAs=Guardar &como...
 
 menuUndo=&Deshacer
 menuRedo=&Rehacer


### PR DESCRIPTION
This pull request makes several improvements to the editor window's menu and status bar behavior, as well as updates to menu item labels for better usability and localization. The main changes include fixing keyboard shortcuts, updating menu labels, and ensuring proper method overrides.

Menu and shortcut improvements:

* Changed the F3 shortcut in the status bar from "Save As" to "Open", aligning it with standard conventions and updating the shortcut assignments accordingly in `TEditorWindow.java`.
* Assigned the F2 shortcut key to the "Save" menu item in `TMenu.java`, ensuring consistency with the status bar and typical editor behavior.

Code quality and behavior:

* Added `@Override` annotations to `onFocus` and `onUnfocus` methods in `TEditorWindow.java` to clarify method overrides and improve code clarity. [[1]](diffhunk://#diff-b5dd42bbba50c7bccfae8b37c274b8c42942ceb6182b032cfdfc342b2effa764R163) [[2]](diffhunk://#diff-b5dd42bbba50c7bccfae8b37c274b8c42942ceb6182b032cfdfc342b2effa764R174)

Menu label and localization updates:

* Updated English and Spanish menu labels in `TMenuBundle.properties` and `TMenuBundle_es.properties` to improve clarity, add ellipses where appropriate, and ensure access keys are correctly set. [[1]](diffhunk://#diff-0e43fe1d7177de8d93a5375a2e5e806ad141807cef89e3b554408f42f6cd0fb6L3-R6) [[2]](diffhunk://#diff-0ee0af799c822c37d60bdde994a901ec976ac8bb4ca0f9a1507a3b61cfb8548cL4-R6)