### PR TITLE
Add additional Unicode character support and corresponding test coverage

### DIFF
--- a/code/src/main/java/casciian/bits/UnicodeWidth.java
+++ b/code/src/main/java/casciian/bits/UnicodeWidth.java
@@ -166,6 +166,7 @@ public class UnicodeWidth {
             || ch == 0x1F5F6
             || ch == 0x1F5D0
             || ch == 0x1F5D7
+            || ch == 0x1F5D1
             || ch == 0x1F5BC;
     }
 

--- a/code/src/test/java/casciian/backend/ScreenEdgeCasesTest.java
+++ b/code/src/test/java/casciian/backend/ScreenEdgeCasesTest.java
@@ -131,6 +131,7 @@ class ScreenEdgeCasesTest {
             screen.putCharXY(1, 0, '好', attr);
             screen.putCharXY(2, 0, '世', attr);
             screen.putCharXY(3, 0, '界', attr);
+            screen.putCharXY(4, 0, 0x1F389, attr); //🎉
         });
     }
 

--- a/code/src/test/java/casciian/bits/StringUtilsTest.java
+++ b/code/src/test/java/casciian/bits/StringUtilsTest.java
@@ -186,4 +186,20 @@ class StringUtilsTest {
         // So "!!!" returns an empty array.
         assertArrayEquals(new byte[0], StringUtils.fromBase64("!!!".getBytes()));
     }
+
+    @Test
+    void testMoreEmojis() {
+        assertEquals(1, StringUtils.width(0x25B6));
+        assertEquals(1, StringUtils.width(0x23F8));
+        assertEquals(1, StringUtils.width(0x25A0));
+        assertEquals(1, StringUtils.width(0x29CF));
+        assertEquals(1, StringUtils.width(0x29D0));
+        assertEquals(2, StringUtils.width(0x1F503));
+        assertEquals(1, StringUtils.width(0x26C1));
+        assertEquals(2, StringUtils.width(0x1F3B5));
+        assertEquals(1, StringUtils.width(0x1F5D1));
+        assertEquals(2, StringUtils.width(0x1F9F9));
+        assertEquals(2, StringUtils.width(0x2705));
+        assertEquals(1, StringUtils.width(0x2699));
+    }
 }


### PR DESCRIPTION
- Extend `isWide` check in `UnicodeWidth` to include `0x1F5D1`.
- Add comprehensive test cases in `StringUtilsTest` for new Unicode ranges.
- Update `ScreenEdgeCasesTest` to handle `0x1F389` (`🎉`) rendering.